### PR TITLE
Add LFS guard pre-commit hook

### DIFF
--- a/.lfs.guard
+++ b/.lfs.guard
@@ -1,0 +1,13 @@
+#!/bin/bash
+# LFS Guard pre-commit hook
+
+# Abort commit if git lfs has tracked files
+if git lfs ls-files | grep -q .; then
+    echo "❌ LFS usage is prohibited in this repo." >&2
+    exit 1
+fi
+
+exit 0
+
+# Manifest (SHA-256)
+# README.md ec7d89494b4b74cd7c85b3045ea923a912ed3d53da07fbbcd85ea3a2a8194077

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-"# wheelhouse" 
+# wheelhouse
+
+This repository prohibits Git LFS usage. Install the provided `.lfs.guard` script as `.git/hooks/pre-commit` to enforce this rule.


### PR DESCRIPTION
## Summary
- convert `.lfs.guard` into an executable pre-commit hook to block Git LFS usage
- document installing the hook in `README.md`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684ce0e201b4832a8b0cb06f35d2a338