### PR TITLE
Update README instructions for lfs guard hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ submodule or standalone project.
 
 1. Edit `requirements.txt` with the packages you need.
 2. Run `./build-wheelhouse.sh` (or `powershell -File build-wheelhouse.ps1`).
-3. Commit the resulting `wheelhouse/` directory with Git LFS enabled.
+3. Run `lfsavoider/install-lfs-guard.sh .` to install the `.lfs.guard`
+   pre-commit hook, then commit the resulting `wheelhouse/` directory
+   normally **without** Git LFS.
 
 The scripts download binary wheels for Windows and manylinux using
 `pip download` and compute a `SHA256SUMS.txt` manifest. No network access


### PR DESCRIPTION
## Summary
- clarify step 3 in README
- mention installing `.lfs.guard` hook using `lfsavoider/install-lfs-guard.sh .`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684db5c83318832ab00e2205c95608f7