### PR TITLE
Add branch parameter to lfsavoider update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ submodule or standalone project.
 3. Run `lfsavoider/install-lfs-guard.sh .` to install the `.lfs.guard`
    pre-commit hook, then commit the resulting `wheelhouse/` directory
    normally **without** Git LFS.
+4. Use `./update-lfsavoider.sh [branch]` (or `pwsh update-lfsavoider.ps1 -Branch branch`)
+   to update the `lfsavoider` submodule and push to the specified branch
+   (defaults to `main`).
 
 The scripts download binary wheels for Windows and manylinux using
 `pip download` and compute a `SHA256SUMS.txt` manifest. No network access

--- a/update-lfsavoider.ps1
+++ b/update-lfsavoider.ps1
@@ -1,5 +1,9 @@
 #!/usr/bin/env pwsh
-Write-Host "Updating all submodules recursively..."
+param(
+    [string]$Branch = 'main'
+)
+
+Write-Host "Updating all submodules recursively on branch '$Branch'..."
 
 # Update submodules to latest remote commit
 git submodule update --remote --recursive
@@ -10,8 +14,8 @@ git add .
 # Commit changes if there are any updates
 if ((git status --porcelain) -ne "") {
     git commit -m "Updated submodules to latest commits"
-    git push origin main
-    Write-Host "Submodules updated and pushed successfully."
+    git push origin $Branch
+    Write-Host "Submodules updated and pushed successfully to '$Branch'."
 } else {
     Write-Host "No changes detected in submodules."
 }

--- a/update-lfsavoider.sh
+++ b/update-lfsavoider.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-echo "Updating all submodules recursively..."
+BRANCH="${1:-main}"
+echo "Updating all submodules recursively on branch '$BRANCH'..."
 
 # Update submodules
 git submodule update --remote --recursive
@@ -10,8 +11,8 @@ git add .
 # Check if any changes occurred
 if [[ $(git status --porcelain) ]]; then
     git commit -m "Updated submodules to latest commits"
-    git push origin main
-    echo "Submodules updated and pushed successfully."
+    git push origin "$BRANCH"
+    echo "Submodules updated and pushed successfully to '$BRANCH'."
 else
     echo "No changes detected in submodules."
 fi


### PR DESCRIPTION
## Summary
- add branch parameter to `update-lfsavoider.sh`
- add branch parameter to `update-lfsavoider.ps1`
- document how to use the new parameter in the README

## Testing
- `bash -n update-lfsavoider.sh`
- `sudo apt-get update` *(passed)*
- `sudo apt-get install -y powershell` *(failed: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb01f138832a8b46bec4ac14ea8e